### PR TITLE
Propaga erros da API de clima

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -11,7 +11,7 @@ async function getWeather() {
         const response = await fetch(`/weather?city=${encodeURIComponent(city)}`);
         const data = await response.json();
 
-        if (data.cod === 200) {
+        if (response.ok) {
             resultDiv.innerHTML = `
                 <strong>Clima em ${data.name}:</strong><br>
                 Temperatura: ${data.main.temp}°C<br>
@@ -20,7 +20,7 @@ async function getWeather() {
                 Vento: ${data.wind.speed} m/s
             `;
         } else {
-            resultDiv.innerHTML = 'Cidade não encontrada.';
+            resultDiv.innerHTML = data.error || 'Cidade não encontrada.';
         }
     } catch (error) {
         resultDiv.innerHTML = 'Erro ao buscar o clima. Tente novamente mais tarde.';

--- a/server.js
+++ b/server.js
@@ -17,11 +17,22 @@ app.get('/weather', async (req, res) => {
         return res.status(400).json({ error: 'Nome da cidade não fornecido.' });
     }
 
+    if (!apiKey) {
+        return res.status(500).json({ error: 'Chave da API não configurada.' });
+    }
+
     const url = `https://api.openweathermap.org/data/2.5/weather?q=${city}&appid=${apiKey}&units=metric&lang=pt_br`;
 
     try {
         const response = await fetch(url);
         const data = await response.json();
+
+        if (!response.ok) {
+            return res
+                .status(response.status)
+                .json({ error: data.message || 'Erro ao buscar dados do clima.' });
+        }
+
         res.json(data);
     } catch (error) {
         res.status(500).json({ error: 'Erro ao buscar dados do clima.' });


### PR DESCRIPTION
## Summary
- Handle missing API key and forward OpenWeather error codes
- Surface server error messages on the client

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ac502e5264832bb2fd6a9c63343254